### PR TITLE
Add the `MakeHeaderValue` trait bound to the `SetRequestHeaderLayer` generic parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to
 - Bumped minimum supported Rust version to `1.85` and changed Rust edition to
   `2024`.
 
+- Add the `MakeHeaderValue` trait bound to the `SetRequestHeaderLayer` generic
+  parameter in the `tower-request` crate (otherwise the resulting type won't
+  implement `Service`)
+
 ## [0.5.1] - 2025.04.04
 
 - Added a `typed_header` method to the `ClientRequest` and `RequestBuilderExt`

--- a/tower-reqwest/src/set_header.rs
+++ b/tower-reqwest/src/set_header.rs
@@ -115,7 +115,10 @@ impl<M> fmt::Debug for SetRequestHeaderLayer<M> {
     }
 }
 
-impl<M> SetRequestHeaderLayer<M> {
+impl<M> SetRequestHeaderLayer<M>
+where
+    M: MakeHeaderValue<reqwest::Request>,
+{
     /// Create a new [`SetRequestHeaderLayer`].
     ///
     /// If a previous value exists for the same header, it is removed and replaced with the new


### PR DESCRIPTION
Without this, one can invoke `overriding()`, `appending()` and so forth with any type for the `make` parameter (such as a `&str`). If that type doesn't implement `MakeHeaderValue`, however, one will receive a very confusing error message when the resulting type doesn't implement `Service`.