### PR TITLE
Rename `build` method to `without_body` in the ClientRequest

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -216,13 +216,13 @@
           git-install-hooks = mkGitHooks {
             "pre-commit" = ''
               echo "⚡️ Running pre-commit checks..."
-              nix build .#check-formatting
+              nix build .#check-formatting -L
             '';
             "pre-push" = ''
               echo "⚡️ Running flake checks..."
-              nix flake check
-               echo "⚡️ Running semver checks..."
-              nix run .#check-semver
+              nix flake check -L
+              echo "⚡️ Running semver checks..."
+              nix run .#check-semver -L
             '';
           };
         }


### PR DESCRIPTION
This PR renames `build` method to `without_body` in `ClientRequest` to better reflect its purpose and API clarity