### PR TITLE
Refine body conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **breaking:** Improved integration with `reqwest`: request body conversion now
+  uses `reqwest::Body::wrap` instead of `into_reqwest_body` method.
+  `ClientRequestBuilder` method `without_body` now returns a `Bytes` type in
+  order to improve compatibility with other HTTP clients.
 - **breaking:** Renamed `build` method to `without_body` in `ClientRequest` to
   better reflect its purpose and improve API clarity.
 - **breaking:** Removed `reqwest` dependency from `tower-http-client` to

--- a/tower-http-client/benches/client.rs
+++ b/tower-http-client/benches/client.rs
@@ -8,7 +8,7 @@ use tokio::time::Instant;
 use tower::{BoxError, ServiceBuilder, util::BoxCloneSyncService};
 use tower_http::ServiceBuilderExt;
 use tower_http_client::{ResponseExt as _, ServiceExt as _};
-use tower_reqwest::{HttpClientLayer, into_reqwest_body};
+use tower_reqwest::HttpClientLayer;
 
 /// A body that can be cloned in order to be sent multiple times.
 type CloneableBody = http_body_util::Full<Bytes>;
@@ -298,7 +298,7 @@ fn benchmark_json(criterion: &mut Criterion) {
                 .layer_fn(BoxCloneSyncService::new)
                 .map_err(BoxError::from)
                 .map_response_body(|body: reqwest::Body| body.map_err(BoxError::from).boxed())
-                .map_request_body(|body: CloneableBody| into_reqwest_body(body))
+                .map_request_body(|body: CloneableBody| reqwest::Body::wrap(body))
                 .layer(HttpClientLayer)
                 .service(reqwest::Client::new())
         },

--- a/tower-http-client/examples/boxed_client.rs
+++ b/tower-http-client/examples/boxed_client.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use tower::{BoxError, Service, ServiceBuilder, util::BoxCloneSyncService};
 use tower_http::ServiceBuilderExt;
 use tower_http_client::{ResponseExt as _, ServiceExt};
-use tower_reqwest::{HttpClientLayer, into_reqwest_body};
+use tower_reqwest::HttpClientLayer;
 
 /// A body that can be cloned in order to be sent multiple times.
 type CloneableBody = http_body_util::Full<Bytes>;
@@ -30,7 +30,7 @@ fn into_tower_http_client(
     ServiceBuilder::new()
         .map_err(BoxError::from)
         .map_response_body(|body: reqwest::Body| body.map_err(BoxError::from).boxed())
-        .map_request_body(into_reqwest_body)
+        .map_request_body(reqwest::Body::wrap)
         .layer(HttpClientLayer)
         .service(client)
 }

--- a/tower-http-client/examples/retry.rs
+++ b/tower-http-client/examples/retry.rs
@@ -9,7 +9,7 @@ use retry_policies::{RetryDecision, policies::ExponentialBackoff};
 use tower::{ServiceBuilder, ServiceExt as _};
 use tower_http::ServiceBuilderExt as _;
 use tower_http_client::client::ServiceExt as _;
-use tower_reqwest::{HttpClientLayer, into_reqwest_body};
+use tower_reqwest::HttpClientLayer;
 use wiremock::{
     Mock, MockServer, ResponseTemplate,
     matchers::{method, path},
@@ -133,7 +133,7 @@ async fn main() -> anyhow::Result<()> {
             ExponentialBackoff::builder().build_with_max_retries(10),
         ))
         // Set the request body type.
-        .map_request_body(|body: http_body_util::Full<Bytes>| into_reqwest_body(body))
+        .map_request_body(|body: http_body_util::Full<Bytes>| reqwest::Body::wrap(body))
         .layer(HttpClientLayer)
         .service(reqwest::Client::new())
         .map_err(anyhow::Error::msg)

--- a/tower-http-client/examples/send_form.rs
+++ b/tower-http-client/examples/send_form.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use tower::{ServiceBuilder, ServiceExt as _};
 use tower_http::ServiceBuilderExt as _;
 use tower_http_client::{ResponseExt as _, ServiceExt as _};
-use tower_reqwest::{HttpClientLayer, into_reqwest_body};
+use tower_reqwest::HttpClientLayer;
 use wiremock::{
     Mock, MockServer, ResponseTemplate,
     matchers::{method, path},
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("-> Creating an HTTP client with Tower layers...");
     let mut client = ServiceBuilder::new()
         // Set the request body type.
-        .map_request_body(|body: http_body_util::Full<Bytes>| into_reqwest_body(body))
+        .map_request_body(|body: http_body_util::Full<Bytes>| reqwest::Body::wrap(body))
         .layer(HttpClientLayer)
         .service(reqwest::Client::new())
         .map_err(anyhow::Error::msg)

--- a/tower-http-client/examples/send_json.rs
+++ b/tower-http-client/examples/send_json.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use tower::{ServiceBuilder, ServiceExt as _};
 use tower_http::ServiceBuilderExt as _;
 use tower_http_client::{ResponseExt as _, ServiceExt as _};
-use tower_reqwest::{HttpClientLayer, into_reqwest_body};
+use tower_reqwest::HttpClientLayer;
 use wiremock::{
     Mock, MockServer, ResponseTemplate,
     matchers::{method, path},
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("-> Creating an HTTP client with Tower layers...");
     let mut client = ServiceBuilder::new()
         // Set the request body type.
-        .map_request_body(|body: http_body_util::Full<Bytes>| into_reqwest_body(body))
+        .map_request_body(|body: http_body_util::Full<Bytes>| reqwest::Body::wrap(body))
         .layer(HttpClientLayer)
         .service(reqwest::Client::new())
         .map_err(anyhow::Error::msg)

--- a/tower-http-client/src/client/client_request.rs
+++ b/tower-http-client/src/client/client_request.rs
@@ -99,6 +99,24 @@ impl<'a, S, Err, RespBody> ClientRequestBuilder<'a, S, Err, RespBody> {
         self.builder.extensions_mut()
     }
 
+    /// Appends a typed header to this request.
+    ///
+    /// This function will append the provided header as a header to the
+    /// internal [`HeaderMap`] being constructed.  Essentially this is
+    /// equivalent to calling [`headers::HeaderMapExt::typed_insert`].
+    #[must_use]
+    #[cfg(feature = "typed-header")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "typed_header")))]
+    pub fn typed_header<T>(mut self, header: T) -> Self
+    where
+        T: headers::Header,
+    {
+        use super::RequestBuilderExt as _;
+
+        self.builder = self.builder.typed_header(header);
+        self
+    }
+
     /// "Consumes" this builder, using the provided `body` to return a
     /// constructed [`ClientRequest`].
     ///
@@ -195,24 +213,6 @@ impl<'a, S, Err, RespBody> ClientRequestBuilder<'a, S, Err, RespBody> {
             request: self.builder.form(form)?,
             _phantom: PhantomData,
         })
-    }
-
-    /// Appends a typed header to this request.
-    ///
-    /// This function will append the provided header as a header to the
-    /// internal [`HeaderMap`] being constructed.  Essentially this is
-    /// equivalent to calling [`headers::HeaderMapExt::typed_insert`].
-    #[must_use]
-    #[cfg(feature = "typed-header")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "typed_header")))]
-    pub fn typed_header<T>(mut self, header: T) -> Self
-    where
-        T: headers::Header,
-    {
-        use super::RequestBuilderExt as _;
-
-        self.builder = self.builder.typed_header(header);
-        self
     }
 }
 

--- a/tower-http-client/src/client/client_request.rs
+++ b/tower-http-client/src/client/client_request.rs
@@ -2,13 +2,11 @@
 
 use std::{any::Any, future::Future, marker::PhantomData};
 
+use bytes::Bytes;
 use http::{Extensions, HeaderMap, HeaderName, HeaderValue, Method, Uri, Version};
 use tower_service::Service;
 
 use super::{IntoUri, ServiceExt as _};
-
-type EmptyBody = http_body_util::Empty<()>;
-const EMPTY_BODY: EmptyBody = EmptyBody::new();
 
 /// An [`http::Request`] builder.
 ///
@@ -124,12 +122,12 @@ impl<'a, S, Err, RespBody> ClientRequestBuilder<'a, S, Err, RespBody> {
     ///
     /// If erroneous data was passed during the query building process.
     #[allow(clippy::missing_panics_doc)]
-    pub fn without_body(self) -> ClientRequest<'a, S, Err, EmptyBody, RespBody> {
+    pub fn without_body(self) -> ClientRequest<'a, S, Err, Bytes, RespBody> {
         ClientRequest {
             service: self.service,
             request: self
                 .builder
-                .body(EMPTY_BODY)
+                .body(Bytes::default())
                 .expect("failed to build request without a body"),
             _phantom: PhantomData,
         }

--- a/tower-http-client/tests/service_ext.rs
+++ b/tower-http-client/tests/service_ext.rs
@@ -74,6 +74,33 @@ async fn test_service_ext_get() -> anyhow::Result<()> {
     Ok(())
 }
 
+// Check that the `without_body` method is useful.
+#[tokio::test]
+async fn test_service_ext_without_body() -> anyhow::Result<()> {
+    let (mock_server, mock_uri) = utils::start_mock_server().await;
+
+    Mock::given(method("GET"))
+        .and(path("/hello"))
+        .respond_with(ResponseTemplate::new(200))
+        // Mounting the mock on the mock server - it's now effective!
+        .mount(&mock_server)
+        .await;
+
+    let client = ServiceBuilder::new()
+        .layer(HttpClientLayer)
+        .service(Client::new());
+
+    let response = client
+        .clone()
+        .get(format!("{mock_uri}/hello"))
+        .without_body()
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+
+    Ok(())
+}
+
 #[cfg(feature = "json")]
 #[tokio::test]
 async fn test_service_ext_put_json() -> anyhow::Result<()> {

--- a/tower-reqwest/src/lib.rs
+++ b/tower-reqwest/src/lib.rs
@@ -4,9 +4,6 @@
 //!
 #![doc = include_utils::include_md!("README.md:description")]
 
-use bytes::Bytes;
-use http_body::Body as HttpBody;
-use http_body_util::BodyDataStream;
 use tower_layer::Layer;
 
 mod adapters;
@@ -41,15 +38,4 @@ impl<S> Layer<S> for HttpClientLayer {
     fn layer(&self, service: S) -> Self::Service {
         HttpClientService(service)
     }
-}
-
-/// Converts an arbitrary body type into the `reqwest::Body` one.
-pub fn into_reqwest_body<B>(body: B) -> reqwest::Body
-where
-    B: HttpBody + Send + Sync + 'static,
-    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-    Bytes: From<B::Data>,
-{
-    let stream = BodyDataStream::new(body);
-    reqwest::Body::wrap_stream(stream)
 }


### PR DESCRIPTION
 - Update reqwest body conversion to use `reqwest::Body::wrap`

    Remove the deprecated `into_reqwest_body` function and update all examples
    and benchmarks to use `reqwest::Body::wrap` instead for converting
    bodies to `reqwest::Body` type.

 - Update `ClientRequestBuilder::without_body` to use `Bytes` instead of `EmptyBody`
