### PR TITLE
0.6.0-alpha.1 pre-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: "Tests"
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: "Run semver compatibility checks"
         run: nix run .#check-semver
+      - name: "Run cargo publish compatibility checks"
+        run: nix run .#check-cargo-publish
 
   tests:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "tower-http-client"
-version = "0.6.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1638,7 +1638,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-reqwest"
-version = "0.6.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["tower-http-client", "tower-reqwest"]
 [workspace.package]
 edition = "2024"
 rust-version = "1.89"
-version = "0.6.0"
+version = "0.6.0-alpha.1"
 categories = [
   "asynchronous",
   "network-programming",
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/alekseysidorov/tower-http-client"
 
 [workspace.dependencies]
-tower-reqwest = { version = "0.6", path = "tower-reqwest" }
+tower-reqwest = { version = "0.6.0-alpha.1", path = "tower-reqwest" }
 
 anyhow = "1.0"
 async-trait = "0.1"

--- a/flake.nix
+++ b/flake.nix
@@ -211,6 +211,16 @@
               ++ buildInputs;
             text = "cargo semver-checks";
           };
+          # Cargo crate publishing compatibility checks
+          check-cargo-publish = pkgs.writeShellApplication {
+            name = "publish-crate";
+            runtimeInputs = [
+              rustToolchains.stable
+            ];
+            text = ''
+              cargo publish --workspace --all-features --dry-run
+            '';
+          };
 
           # Convenience script to install git hooks
           git-install-hooks = mkGitHooks {
@@ -223,6 +233,8 @@
               nix flake check -L
               echo "⚡️ Running semver checks..."
               nix run .#check-semver -L
+              echo "⚡️ Running cargo publish compatibility checks..."
+              nix run .#check-cargo-publish -L
             '';
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -213,7 +213,7 @@
           };
           # Cargo crate publishing compatibility checks
           check-cargo-publish = pkgs.writeShellApplication {
-            name = "publish-crate";
+            name = "run-cargo-publish-checks";
             runtimeInputs = [
               rustToolchains.stable
             ];

--- a/tower-http-client/Cargo.toml
+++ b/tower-http-client/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "tower-http-client"
-version.workspace = true
-edition.workspace = true
-rust-version.workspace = true
 description = "Extra Tower middlewares and utilities for HTTP clients."
 documentation = "https://docs.rs/crate/tower-http-client"
 readme = "README.md"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords.workspace = true

--- a/tower-reqwest/Cargo.toml
+++ b/tower-reqwest/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "tower-reqwest"
-version.workspace = true
-edition.workspace = true
-rust-version.workspace = true
 description = "Adapter between reqwest and tower-http crates."
 documentation = "https://docs.rs/crate/tower-reqwest"
 readme = "README.md"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
- **breaking:** Improved integration with `reqwest`: request body conversion now
  uses `reqwest::Body::wrap` instead of `into_reqwest_body` method.
  `ClientRequestBuilder` method `without_body` now returns a `Bytes` type in
  order to improve compatibility with other HTTP clients.
- **breaking:** Renamed `build` method to `without_body` in `ClientRequest` to
  better reflect its purpose and improve API clarity.
- **breaking:** Removed `reqwest` dependency from `tower-http-client` to
  eliminate dependency on specific versions of `reqwest`. The crate is now fully
  generic and does not tie to any HTTP client implementation. Users needing
  `reqwest`-specific features should use **`tower-reqwest`** directly.
- **breaking:** Updated the request adapter (`HttpClientService` /
  `ExecuteRequestFuture`) to propagate `S::Error` directly (now constrained to
  `request::Error`) instead of wrapping it in a crate-specific error type.
- Refactored `ExecuteRequestFuture` in `tower-reqwest` to remove unnecessary
  double pinning, simplifying the internal structure.