### PR TITLE
Add the `MakeHeaderValue` trait bound to the `SetRequestHeaderLayer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Add the `MakeHeaderValue` trait bound to the `SetRequestHeaderLayer` generic
+  parameter in the `tower-request` crate (otherwise the resulting type won't
+  implement `Service`)
 - **breaking:** Improved integration with `reqwest`: request body conversion now
   uses `reqwest::Body::wrap` instead of `into_reqwest_body` method.
   `ClientRequestBuilder` method `without_body` now returns a `Bytes` type in
@@ -23,8 +26,6 @@ and this project adheres to
   `request::Error`) instead of wrapping it in a crate-specific error type.
 - Refactored `ExecuteRequestFuture` in `tower-reqwest` to remove unnecessary
   double pinning, simplifying the internal structure.
-- Remove `doc_auto_cfg` attribute
-  [PR](https://github.com/rust-lang/rust/pull/138907).
 
 ## [0.5.3] - 2025.09.23
 

--- a/tower-reqwest/src/set_header.rs
+++ b/tower-reqwest/src/set_header.rs
@@ -115,7 +115,10 @@ impl<M> fmt::Debug for SetRequestHeaderLayer<M> {
     }
 }
 
-impl<M> SetRequestHeaderLayer<M> {
+impl<M> SetRequestHeaderLayer<M>
+where
+    M: MakeHeaderValue<reqwest::Request>,
+{
     /// Create a new [`SetRequestHeaderLayer`].
     ///
     /// If a previous value exists for the same header, it is removed and replaced with the new


### PR DESCRIPTION
Without this, one can invoke `overriding()`, `appending()` and so forth with any type for the `make` parameter (such as a `&str`). If that type doesn't implement `MakeHeaderValue`, however, one will receive a very confusing error message when the resulting type doesn't implement `Service`.