### PR TITLE
Unify body implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **breaking:** Unified body types across `ClientRequestBuilder` methods.
+  `form()` now returns `Bytes` instead of `String`, and `send()` on the builder
+  requires `From<Bytes>` instead of `Default`. All standard body-producing
+  methods (`send`, `without_body`, `json`, `form`) now uniformly produce
+  `Bytes`, requiring only a single `From<Bytes>` bound on the service request
+  body type.
 - **Breaking:** `url` and `serde` dependencies are now optional. Some
   functionality has been moved behind feature flags `json` / `form` (enabling
   `serde`) and `url`.

--- a/tower-http-client/src/client/request_ext.rs
+++ b/tower-http-client/src/client/request_ext.rs
@@ -43,7 +43,7 @@ pub trait RequestBuilderExt: Sized + Sealed {
     fn form<T: serde::Serialize + ?Sized>(
         self,
         form: &T,
-    ) -> Result<http::Request<String>, SetBodyError<serde_urlencoded::ser::Error>>;
+    ) -> Result<http::Request<bytes::Bytes>, SetBodyError<serde_urlencoded::ser::Error>>;
 
     /// Appends a typed header to this request.
     ///
@@ -80,7 +80,7 @@ impl RequestBuilderExt for http::request::Builder {
     fn form<T: serde::Serialize + ?Sized>(
         mut self,
         form: &T,
-    ) -> Result<http::Request<String>, SetBodyError<serde_urlencoded::ser::Error>> {
+    ) -> Result<http::Request<bytes::Bytes>, SetBodyError<serde_urlencoded::ser::Error>> {
         use http::{HeaderValue, header::CONTENT_TYPE};
 
         let string = serde_urlencoded::to_string(form).map_err(SetBodyError::Encode)?;
@@ -90,7 +90,9 @@ impl RequestBuilderExt for http::request::Builder {
                 HeaderValue::from_static("application/x-www-form-urlencoded"),
             );
         }
-        self.body(string).map_err(SetBodyError::Body)
+
+        self.body(bytes::Bytes::from(string))
+            .map_err(SetBodyError::Body)
     }
 
     #[cfg(feature = "typed-header")]

--- a/tower-http-client/tests/service_ext.rs
+++ b/tower-http-client/tests/service_ext.rs
@@ -101,8 +101,8 @@ async fn test_service_ext_without_body() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "json")]
 #[tokio::test]
+#[cfg(feature = "json")]
 async fn test_service_ext_put_json() -> anyhow::Result<()> {
     use http::header::CONTENT_TYPE;
     use tower_http_client::client::ResponseExt as _;
@@ -154,8 +154,8 @@ async fn test_service_ext_put_json() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "typed-header")]
 #[tokio::test]
+#[cfg(feature = "typed-header")]
 async fn test_service_ext_typed_header() -> anyhow::Result<()> {
     use headers::{HeaderMapExt as _, UserAgent};
     use wiremock::Request;


### PR DESCRIPTION
**breaking:** Unified body types across `ClientRequestBuilder` methods.
  `form()` now returns `Bytes` instead of `String`, and `send()` on the builder
  requires `From<Bytes>` instead of `Default`. All standard body-producing
  methods (`send`, `without_body`, `json`, `form`) now uniformly produce
  `Bytes`, requiring only a single `From<Bytes>` bound on the service request
  body type.