### PR TITLE
Add query feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to
 
 - Added a `query` method to `ClientRequestBuilder` and `RequestBuilderExt` for
   setting URL query parameters from any `serde::Serialize` type. The method
-  replaces any existing query string entirely. Available behind the `query`
-  feature flag.
+  replaces any existing query string entirely. Enabled by default via the
+  `query` feature flag, can be opted out with `default-features = false`.
 
 - **breaking:** Unified body types across `ClientRequestBuilder` methods.
   `form()` now returns `Bytes` instead of `String`, and `send()` on the builder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,31 +8,43 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Added a `query` method to `ClientRequestBuilder` and `RequestBuilderExt` for
+  setting URL query parameters from any `serde::Serialize` type. The method
+  replaces any existing query string entirely. Available behind the `query`
+  feature flag.
+
 - **breaking:** Unified body types across `ClientRequestBuilder` methods.
   `form()` now returns `Bytes` instead of `String`, and `send()` on the builder
   requires `From<Bytes>` instead of `Default`. All standard body-producing
   methods (`send`, `without_body`, `json`, `form`) now uniformly produce
   `Bytes`, requiring only a single `From<Bytes>` bound on the service request
   body type.
+
 - **Breaking:** `url` and `serde` dependencies are now optional. Some
   functionality has been moved behind feature flags `json` / `form` (enabling
   `serde`) and `url`.
+
 - Add the `MakeHeaderValue` trait bound to the `SetRequestHeaderLayer` generic
   parameter in the `tower-request` crate (otherwise the resulting type won't
   implement `Service`)
+
 - **breaking:** Improved integration with `reqwest`: request body conversion now
   uses `reqwest::Body::wrap` instead of `into_reqwest_body` method.
   `ClientRequestBuilder` method `without_body` now returns a `Bytes` type in
   order to improve compatibility with other HTTP clients.
+
 - **breaking:** Renamed `build` method to `without_body` in `ClientRequest` to
   better reflect its purpose and improve API clarity.
+
 - **breaking:** Removed `reqwest` dependency from `tower-http-client` to
   eliminate dependency on specific versions of `reqwest`. The crate is now fully
   generic and does not tie to any HTTP client implementation. Users needing
   `reqwest`-specific features should use **`tower-reqwest`** directly.
+
 - **breaking:** Updated the request adapter (`HttpClientService` /
   `ExecuteRequestFuture`) to propagate `S::Error` directly (now constrained to
   `request::Error`) instead of wrapping it in a crate-specific error type.
+
 - Refactored `ExecuteRequestFuture` in `tower-reqwest` to remove unnecessary
   double pinning, simplifying the internal structure.
 
@@ -40,33 +52,45 @@ and this project adheres to
 
 - Improved `Debug` implementations for `ClientRequest` and
   `ClientRequestBuilder`.
+
 - Added `From<ClientRequest>` implementation for `http::Request` and
   `From<ClientRequestBuilder>` for `http::request::Builder` to help with
   debugging and testing.
+
 - Bump minimum supported Rust version to `1.88.0`.
 
 ## [0.5.2] - 2025.04.04
 
 - Added a `typed_header` method to the `ClientRequest` and `RequestBuilderExt`
   for typed header insertion.
+
 - Made trait `RequestBuilderExt` sealed.
 
 ## [0.5.1] - 2025.04.01
 
 - **breaking** `body_reader` implementation has been replaced with the
   `http_body_reader` crate.
+
 - Added a `form` method to the `BodyReader` to decode form data.
+
 - **breaking:** Split the old `ClientRequest` into separate builder and request
   structs with updated error handling.
+
 - Introduced a `RequestBuilderExt` trait to extend the `http::request::Builder`
   with additional methods to send a form data and a JSON objects.
+
 - Bump minimum supported Rust version to `1.81`.
+
 - **breaking:** Made `request_builder` module private.
+
 - Added a `form` method to the `ClientRequest` to send a form data.
+
 - **breaking:** Removed the own implementation of the `BoxCloneSyncService`,
   please use the `tower::util::BoxCloneSyncService` instead.
+
 - Added an `auth` module to the `tower-reqwest` crate, which provides a way to
   add an authorization header to the requests.
+
 - Added a `set-header` module to the `tower-reqwest` crate, which provides a way
   to modify the request headers.
 
@@ -79,17 +103,24 @@ and this project adheres to
 
 - **breaking:** Extensions and utilities for Tower services that provides HTTP
   client implementations have been moved to the `client` module.
+
 - **breaking:** `ClientRequest` and `ServiceBuilderExt` methods now use the
   `IntoUri` trait instead of `Uri: TryFrom` conversion in order to improve
   interopability with the `url` crate.
+
 - Added `#[from]` and `#[source]` to `Error` and `ClientError` to expose the
   underlying source error.
+
 - Added a `BoxCloneSyncService`, borrowed from this
   [PR](https://github.com/tower-rs/tower/pull/777).
+
 - **breaking:** `request` module has been renamed to the `request_builder`.
+
 - **breaking:** Removed `reqwest-middleware` feature from the
   `tower-http-client` and `tower-http` crates.
+
 - Added a [retry](tower-http-client/examples/retry.rs) example.
+
 - Added a [rate-limiter](tower-http-client/examples/rate_limiter.rs) example.
 - **breaking:** Changed `ServiceBuilder::execute` signature to be more
   compatible with the `Service::call` method.
@@ -107,14 +138,19 @@ and this project adheres to
 ## [0.3.0] - 2024.04.30
 
 - Added an `ResponseExt` extension trait.
+
 - Added a `json` feature to enable reading and writing JSON bodies in requests
   and responses.
+
 - Added a `request` module with the useful utilities like `ClientRequest` for
   constructing HTTP requests.
+
 - A separate feature `util` has been removed, now this functionality is always
   available.
+
 - Added a new module `body_reader` in the [`tower-http-client`] to simplify the
   reading the response body in the most common cases.
+
 - `tower_http_client::util::HttpClientExt` has been replaced by the
   `tower_http_client::ServiceExt`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,19 +506,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -855,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -886,9 +886,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.86"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36139f1c97c42c0c86a411910b04e48d4939a0376e6e0f989420cbdee0120e5"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1025,18 +1025,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1045,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1143,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1155,6 +1155,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1230,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1524,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -1539,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1599,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "tower-http-client"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1637,7 +1643,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-reqwest"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -1733,7 +1739,7 @@ version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1789,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.109"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff9c7baef35ac3c0e17d8bfc9ad75eb62f85a2f02bccc906699dadb0aa9c622"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1802,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.59"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24699cd39db9966cf6e2ef10d2f72779c961ad905911f395ea201c3ec9f545d"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1816,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.109"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39455e84ad887a0bbc93c116d72403f1bb0a39e37dd6f235a43e2128a0c7f1fd"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1826,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.109"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff4761f60b0b51fd13fec8764167b7bbcc34498ce3e52805fe1db6f2d56b6d6"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1839,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.109"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6a171c53d98021a93a474c4a4579d76ba97f9517d871bc12e27640f218b6dd"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -1895,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.86"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668fa5d00434e890a452ab060d24e3904d1be93f7bb01b70e5603baa2b8ab23b"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2171,18 +2177,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,6 +1612,7 @@ dependencies = [
  "http-body-reader",
  "http-body-util",
  "include-utils",
+ "pretty_assertions",
  "reqwest",
  "reqwest-middleware",
  "retry-policies",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["tower-http-client", "tower-reqwest"]
 [workspace.package]
 edition = "2024"
 rust-version = "1.89"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 categories = [
   "asynchronous",
   "network-programming",
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/alekseysidorov/tower-http-client"
 
 [workspace.dependencies]
-tower-reqwest = { version = "0.6.0-alpha.1", path = "tower-reqwest" }
+tower-reqwest = { version = "0.6.0-alpha.2", path = "tower-reqwest" }
 
 anyhow = "1.0"
 async-trait = "0.1"

--- a/tower-http-client/Cargo.toml
+++ b/tower-http-client/Cargo.toml
@@ -38,6 +38,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
+pretty_assertions = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 reqwest-middleware = { workspace = true }
 retry-policies = { workspace = true }

--- a/tower-http-client/Cargo.toml
+++ b/tower-http-client/Cargo.toml
@@ -61,7 +61,7 @@ form = ["dep:serde", "dep:serde_urlencoded", "http-body-reader/form"]
 json = ["dep:serde", "dep:serde_json", "http-body-reader/json"]
 url = ["dep:url"]
 typed-header = ["dep:headers"]
-query = ["dep:serde_urlencoded"]
+query = ["dep:serde", "dep:serde_urlencoded"]
 
 [[example]]
 name = "send_json"

--- a/tower-http-client/Cargo.toml
+++ b/tower-http-client/Cargo.toml
@@ -55,11 +55,12 @@ tower-reqwest = { workspace = true }
 wiremock = { workspace = true }
 
 [features]
-default = ["form", "json", "typed-header"]
+default = ["form", "json", "typed-header", "query"]
 form = ["dep:serde", "dep:serde_urlencoded", "http-body-reader/form"]
 json = ["dep:serde", "dep:serde_json", "http-body-reader/json"]
 url = ["dep:url"]
 typed-header = ["dep:headers"]
+query = ["dep:serde_urlencoded"]
 
 [[example]]
 name = "send_json"

--- a/tower-http-client/src/client/client_request.rs
+++ b/tower-http-client/src/client/client_request.rs
@@ -214,6 +214,18 @@ impl<'a, S, Err, RespBody> ClientRequestBuilder<'a, S, Err, RespBody> {
             _phantom: PhantomData,
         })
     }
+
+    #[cfg(feature = "query")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
+    pub fn query<T: serde::Serialize + ?Sized>(
+        mut self,
+        value: &T,
+    ) -> Result<Self, super::request_ext::SetQueryError> {
+        use super::RequestBuilderExt as _;
+
+        self.builder = self.builder.query(value)?;
+        Ok(self)
+    }
 }
 
 impl<S, Err, RespBody> std::fmt::Debug for ClientRequestBuilder<'_, S, Err, RespBody> {

--- a/tower-http-client/src/client/client_request.rs
+++ b/tower-http-client/src/client/client_request.rs
@@ -215,6 +215,32 @@ impl<'a, S, Err, RespBody> ClientRequestBuilder<'a, S, Err, RespBody> {
         })
     }
 
+    /// Sets the query string of the URL.
+    ///
+    /// Serializes the given value into a query string using [`serde_urlencoded`]
+    /// and replaces the existing query string of the URL entirely. Any previously
+    /// set query parameters are discarded.
+    ///
+    /// ```text
+    /// // "existing=1" is lost
+    /// .uri("http://example.com/path?existing=1")
+    /// .query(&[("key", "value")])
+    /// // => "http://example.com/path?key=value"
+    /// ```
+    ///
+    /// Duplicate keys are preserved as-is:
+    /// `.query(&[("foo", "a"), ("foo", "b")])` produces `"foo=a&foo=b"`.
+    ///
+    /// # Note
+    ///
+    /// This method does not support a single key-value tuple directly.
+    /// Use a slice like `.query(&[("key", "val")])` instead.
+    /// Structs and maps that serialize into key-value pairs are also supported.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`super::request_ext::SetQueryError`] if the provided value cannot be serialized
+    /// into a query string, or if the resulting URI is invalid.
     #[cfg(feature = "query")]
     #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
     pub fn query<T: serde::Serialize + ?Sized>(

--- a/tower-http-client/src/client/client_request.rs
+++ b/tower-http-client/src/client/client_request.rs
@@ -221,21 +221,14 @@ impl<'a, S, Err, RespBody> ClientRequestBuilder<'a, S, Err, RespBody> {
     /// and replaces the existing query string of the URL entirely. Any previously
     /// set query parameters are discarded.
     ///
-    /// ```text
-    /// // "existing=1" is lost
-    /// .uri("http://example.com/path?existing=1")
-    /// .query(&[("key", "value")])
-    /// // => "http://example.com/path?key=value"
-    /// ```
+    /// # Notes
     ///
-    /// Duplicate keys are preserved as-is:
-    /// `.query(&[("foo", "a"), ("foo", "b")])` produces `"foo=a&foo=b"`.
+    /// - Duplicate keys are preserved as-is:
+    ///   `.query(&[("foo", "a"), ("foo", "b")])` produces `"foo=a&foo=b"`.
     ///
-    /// # Note
-    ///
-    /// This method does not support a single key-value tuple directly.
-    /// Use a slice like `.query(&[("key", "val")])` instead.
-    /// Structs and maps that serialize into key-value pairs are also supported.
+    /// - This method does not support a single key-value tuple directly.
+    ///   Use a slice like `.query(&[("key", "val")])` instead.
+    ///   Structs and maps that serialize into key-value pairs are also supported.
     ///
     /// # Errors
     ///

--- a/tower-http-client/src/client/client_request.rs
+++ b/tower-http-client/src/client/client_request.rs
@@ -239,14 +239,14 @@ impl<'a, S, Err, RespBody> ClientRequestBuilder<'a, S, Err, RespBody> {
     ///
     /// # Errors
     ///
-    /// Returns a [`super::request_ext::SetQueryError`] if the provided value cannot be serialized
-    /// into a query string, or if the resulting URI is invalid.
+    /// Returns a [`serde_urlencoded::ser::Error`] if the provided value cannot be serialized
+    /// into a query string.
     #[cfg(feature = "query")]
     #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
     pub fn query<T: serde::Serialize + ?Sized>(
         mut self,
         value: &T,
-    ) -> Result<Self, super::request_ext::SetQueryError> {
+    ) -> Result<Self, serde_urlencoded::ser::Error> {
         use super::RequestBuilderExt as _;
 
         self.builder = self.builder.query(value)?;

--- a/tower-http-client/src/client/into_uri.rs
+++ b/tower-http-client/src/client/into_uri.rs
@@ -6,7 +6,7 @@ use private::Sealed;
 /// This trait is sealed and implemented only for the most suitable types.
 ///
 /// Unlike the similar trait in the Reqwest, this one describes a type's representation
-/// that implements [`TryInto<Uri>`]. This approach can pass third-party types  like [`url::Url`]
+/// that implements [`TryInto<Uri>`]. This approach can pass third-party types like `url::Url`
 /// directly to the [`http::request::Builder::uri`] without any wrappers.
 pub trait IntoUri: Sealed {
     /// Which kind of value should be converted to the Uri via [`TryInto<Uri>`]

--- a/tower-http-client/src/client/request_ext.rs
+++ b/tower-http-client/src/client/request_ext.rs
@@ -63,21 +63,14 @@ pub trait RequestBuilderExt: Sized + Sealed {
     /// and replaces the existing query string of the URL entirely. Any previously
     /// set query parameters are discarded.
     ///
-    /// ```text
-    /// // "existing=1" is lost
-    /// .uri("http://example.com/path?existing=1")
-    /// .query(&[("key", "value")])
-    /// // => "http://example.com/path?key=value"
-    /// ```
+    /// # Notes
     ///
-    /// Duplicate keys are preserved as-is:
-    /// `.query(&[("foo", "a"), ("foo", "b")])` produces `"foo=a&foo=b"`.
+    /// - Duplicate keys are preserved as-is:
+    ///   `.query(&[("foo", "a"), ("foo", "b")])` produces `"foo=a&foo=b"`.
     ///
-    /// # Note
-    ///
-    /// This method does not support a single key-value tuple directly.
-    /// Use a slice like `.query(&[("key", "val")])` instead.
-    /// Structs and maps that serialize into key-value pairs are also supported.
+    /// - This method does not support a single key-value tuple directly.
+    ///   Use a slice like `.query(&[("key", "val")])` instead.
+    ///   Structs and maps that serialize into key-value pairs are also supported.
     ///
     /// # Errors
     ///

--- a/tower-http-client/src/client/request_ext.rs
+++ b/tower-http-client/src/client/request_ext.rs
@@ -153,3 +153,39 @@ mod private {
 
     impl Sealed for http::request::Builder {}
 }
+
+#[cfg(all(test, feature = "query"))]
+mod query_tests {
+    use pretty_assertions::assert_eq;
+    use tower_http::BoxError;
+
+    use super::*;
+
+    #[test]
+    fn test_query_happy_path() -> Result<(), BoxError> {
+        let request = http::Request::builder()
+            .uri("http://example.com/path")
+            .query(&[("key", "value")])?
+            .body(())?;
+
+        assert_eq!(request.uri().query(), Some("key=value"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_query_without_uri() -> Result<(), BoxError> {
+        let request = http::Request::builder()
+            .query(&[("key", "value")])?
+            .body(())?;
+
+        assert_eq!(request.uri().query(), Some("key=value"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_query_invalid() {
+        let error = http::Request::builder().query(&42).unwrap_err();
+
+        assert!(matches!(error, SetQueryError::Encode(_)));
+    }
+}

--- a/tower-http-client/src/client/request_ext.rs
+++ b/tower-http-client/src/client/request_ext.rs
@@ -13,8 +13,30 @@ pub enum SetBodyError<S> {
     Encode(S),
 }
 
+#[cfg(feature = "query")]
+#[cfg_attr(docsrs, doc(cfg(feature = "query")))]
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub enum SetQueryError {
+    InvalidUri(http::uri::InvalidUri),
+    InvalidUriParts(http::uri::InvalidUriParts),
+    Encode(serde_urlencoded::ser::Error),
+}
+
 /// Extension trait for the [`http::request::Builder`].
 pub trait RequestBuilderExt: Sized + Sealed {
+    /// Appends a typed header to this request.
+    ///
+    /// This function will append the provided header as a header to the
+    /// internal [`http::HeaderMap`] being constructed.  Essentially this is
+    /// equivalent to calling [`headers::HeaderMapExt::typed_insert`].
+    #[must_use]
+    #[cfg(feature = "typed-header")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "typed-header")))]
+    fn typed_header<T>(self, header: T) -> Self
+    where
+        T: headers::Header;
+
     /// Sets a JSON body for this request.
     ///
     /// Additionally this method adds a `CONTENT_TYPE` header for JSON body.
@@ -45,20 +67,26 @@ pub trait RequestBuilderExt: Sized + Sealed {
         form: &T,
     ) -> Result<http::Request<bytes::Bytes>, SetBodyError<serde_urlencoded::ser::Error>>;
 
-    /// Appends a typed header to this request.
-    ///
-    /// This function will append the provided header as a header to the
-    /// internal [`http::HeaderMap`] being constructed.  Essentially this is
-    /// equivalent to calling [`headers::HeaderMapExt::typed_insert`].
-    #[must_use]
-    #[cfg(feature = "typed-header")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "typed-header")))]
-    fn typed_header<T>(self, header: T) -> Self
-    where
-        T: headers::Header;
+    #[cfg(feature = "query")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
+    fn query<T: serde::Serialize + ?Sized>(self, query: &T) -> Result<Self, SetQueryError>;
 }
 
 impl RequestBuilderExt for http::request::Builder {
+    #[cfg(feature = "typed-header")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "typed-header")))]
+    fn typed_header<T>(mut self, header: T) -> Self
+    where
+        T: headers::Header,
+    {
+        use headers::HeaderMapExt;
+
+        if let Some(headers) = self.headers_mut() {
+            headers.typed_insert(header);
+        }
+        self
+    }
+
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     fn json<T: serde::Serialize + ?Sized>(
@@ -95,18 +123,28 @@ impl RequestBuilderExt for http::request::Builder {
             .map_err(SetBodyError::Body)
     }
 
-    #[cfg(feature = "typed-header")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "typed-header")))]
-    fn typed_header<T>(mut self, header: T) -> Self
-    where
-        T: headers::Header,
-    {
-        use headers::HeaderMapExt;
+    #[cfg(feature = "query")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
+    fn query<T: serde::Serialize + ?Sized>(self, query: &T) -> Result<Self, SetQueryError> {
+        use http::uri::PathAndQuery;
 
-        if let Some(headers) = self.headers_mut() {
-            headers.typed_insert(header);
-        }
-        self
+        let mut parts = self.uri_ref().cloned().unwrap_or_default().into_parts();
+        let new_path_and_query = {
+            // If the URI doesn't have a path, we need to set it to "/" so that the query string can be appended correctly.
+            let path = parts
+                .path_and_query
+                .as_ref()
+                .map_or_else(|| "/", |pq| pq.path());
+
+            let query_string = serde_urlencoded::to_string(query).map_err(SetQueryError::Encode)?;
+            let pq_str = [path, "?", &query_string].concat();
+            PathAndQuery::try_from(pq_str).map_err(SetQueryError::InvalidUri)?
+        };
+
+        parts.path_and_query = Some(new_path_and_query);
+        let uri = http::Uri::from_parts(parts).map_err(SetQueryError::InvalidUriParts)?;
+
+        Ok(self.uri(uri))
     }
 }
 

--- a/tower-http-client/src/client/request_ext.rs
+++ b/tower-http-client/src/client/request_ext.rs
@@ -13,13 +13,17 @@ pub enum SetBodyError<S> {
     Encode(S),
 }
 
+/// An error that can occur when setting a query string on a request.
 #[cfg(feature = "query")]
 #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
 #[derive(Debug, Error)]
 #[error(transparent)]
 pub enum SetQueryError {
+    /// The resulting URI is invalid.
     InvalidUri(http::uri::InvalidUri),
+    /// The resulting URI parts are invalid.
     InvalidUriParts(http::uri::InvalidUriParts),
+    /// An error occurred while serializing the query parameters.
     Encode(serde_urlencoded::ser::Error),
 }
 
@@ -67,6 +71,32 @@ pub trait RequestBuilderExt: Sized + Sealed {
         form: &T,
     ) -> Result<http::Request<bytes::Bytes>, SetBodyError<serde_urlencoded::ser::Error>>;
 
+    /// Sets the query string of the URL.
+    ///
+    /// Serializes the given value into a query string using [`serde_urlencoded`]
+    /// and replaces the existing query string of the URL entirely. Any previously
+    /// set query parameters are discarded.
+    ///
+    /// ```text
+    /// // "existing=1" is lost
+    /// .uri("http://example.com/path?existing=1")
+    /// .query(&[("key", "value")])
+    /// // => "http://example.com/path?key=value"
+    /// ```
+    ///
+    /// Duplicate keys are preserved as-is:
+    /// `.query(&[("foo", "a"), ("foo", "b")])` produces `"foo=a&foo=b"`.
+    ///
+    /// # Note
+    ///
+    /// This method does not support a single key-value tuple directly.
+    /// Use a slice like `.query(&[("key", "val")])` instead.
+    /// Structs and maps that serialize into key-value pairs are also supported.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SetQueryError`] if the provided value cannot be serialized
+    /// into a query string, or if the resulting URI is invalid.
     #[cfg(feature = "query")]
     #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
     fn query<T: serde::Serialize + ?Sized>(self, query: &T) -> Result<Self, SetQueryError>;
@@ -162,7 +192,7 @@ mod query_tests {
     use super::*;
 
     #[test]
-    fn test_query_happy_path() -> Result<(), BoxError> {
+    fn test_query_basic() -> Result<(), BoxError> {
         let request = http::Request::builder()
             .uri("http://example.com/path")
             .query(&[("key", "value")])?
@@ -183,7 +213,72 @@ mod query_tests {
     }
 
     #[test]
-    fn test_query_invalid() {
+    fn test_query_overwrites_existing() -> Result<(), BoxError> {
+        let request = http::Request::builder()
+            .uri("http://example.com/path?existing=1")
+            .query(&[("key", "value")])?
+            .body(())?;
+
+        // "existing=1" must be gone
+        assert_eq!(request.uri().query(), Some("key=value"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_query_last_call_wins() -> Result<(), BoxError> {
+        let request = http::Request::builder()
+            .uri("http://example.com/path")
+            .query(&[("first", "1")])?
+            .query(&[("second", "2")])?
+            .body(())?;
+
+        // Only the last call survives
+        assert_eq!(request.uri().query(), Some("second=2"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_query_duplicate_keys() -> Result<(), BoxError> {
+        let request = http::Request::builder()
+            .uri("http://example.com/path")
+            .query(&[("foo", "a"), ("foo", "b")])?
+            .body(())?;
+
+        assert_eq!(request.uri().query(), Some("foo=a&foo=b"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_query_struct() -> Result<(), BoxError> {
+        #[derive(serde::Serialize)]
+        struct Params {
+            page: u32,
+            limit: u32,
+        }
+
+        let request = http::Request::builder()
+            .uri("http://example.com/path")
+            .query(&Params { page: 2, limit: 10 })?
+            .body(())?;
+
+        assert_eq!(request.uri().query(), Some("page=2&limit=10"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_query_special_characters_are_encoded() -> Result<(), BoxError> {
+        let request = http::Request::builder()
+            .uri("http://example.com/path")
+            .query(&[("key", "hello world")])?
+            .body(())?;
+
+        assert_eq!(request.uri().query(), Some("key=hello+world"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_query_encode_error() {
+        // Scalars (e.g. integers) are not supported by serde_urlencoded
         let error = http::Request::builder().query(&42).unwrap_err();
 
         assert!(matches!(error, SetQueryError::Encode(_)));

--- a/tower-http-client/src/client/request_ext.rs
+++ b/tower-http-client/src/client/request_ext.rs
@@ -13,20 +13,6 @@ pub enum SetBodyError<S> {
     Encode(S),
 }
 
-/// An error that can occur when setting a query string on a request.
-#[cfg(feature = "query")]
-#[cfg_attr(docsrs, doc(cfg(feature = "query")))]
-#[derive(Debug, Error)]
-#[error(transparent)]
-pub enum SetQueryError {
-    /// The resulting URI is invalid.
-    InvalidUri(http::uri::InvalidUri),
-    /// The resulting URI parts are invalid.
-    InvalidUriParts(http::uri::InvalidUriParts),
-    /// An error occurred while serializing the query parameters.
-    Encode(serde_urlencoded::ser::Error),
-}
-
 /// Extension trait for the [`http::request::Builder`].
 pub trait RequestBuilderExt: Sized + Sealed {
     /// Appends a typed header to this request.
@@ -95,11 +81,14 @@ pub trait RequestBuilderExt: Sized + Sealed {
     ///
     /// # Errors
     ///
-    /// Returns a [`SetQueryError`] if the provided value cannot be serialized
-    /// into a query string, or if the resulting URI is invalid.
+    /// Returns a [`serde_urlencoded::ser::Error`] if the provided value cannot be serialized
+    /// into a query string.
     #[cfg(feature = "query")]
     #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
-    fn query<T: serde::Serialize + ?Sized>(self, query: &T) -> Result<Self, SetQueryError>;
+    fn query<T: serde::Serialize + ?Sized>(
+        self,
+        query: &T,
+    ) -> Result<Self, serde_urlencoded::ser::Error>;
 }
 
 impl RequestBuilderExt for http::request::Builder {
@@ -155,7 +144,10 @@ impl RequestBuilderExt for http::request::Builder {
 
     #[cfg(feature = "query")]
     #[cfg_attr(docsrs, doc(cfg(feature = "query")))]
-    fn query<T: serde::Serialize + ?Sized>(self, query: &T) -> Result<Self, SetQueryError> {
+    fn query<T: serde::Serialize + ?Sized>(
+        self,
+        query: &T,
+    ) -> Result<Self, serde_urlencoded::ser::Error> {
         use http::uri::PathAndQuery;
 
         let mut parts = self.uri_ref().cloned().unwrap_or_default().into_parts();
@@ -166,13 +158,15 @@ impl RequestBuilderExt for http::request::Builder {
                 .as_ref()
                 .map_or_else(|| "/", |pq| pq.path());
 
-            let query_string = serde_urlencoded::to_string(query).map_err(SetQueryError::Encode)?;
+            let query_string = serde_urlencoded::to_string(query)?;
             let pq_str = [path, "?", &query_string].concat();
-            PathAndQuery::try_from(pq_str).map_err(SetQueryError::InvalidUri)?
+            // serde_urlencoded always produces valid ASCII, so this can never fail.
+            PathAndQuery::try_from(pq_str).expect("invalid path and query after encoding")
         };
 
         parts.path_and_query = Some(new_path_and_query);
-        let uri = http::Uri::from_parts(parts).map_err(SetQueryError::InvalidUriParts)?;
+        // The parts came from a valid URI with only path_and_query replaced, so this can never fail.
+        let uri = http::Uri::from_parts(parts).expect("invalid URI parts after setting query");
 
         Ok(self.uri(uri))
     }
@@ -279,8 +273,6 @@ mod query_tests {
     #[test]
     fn test_query_encode_error() {
         // Scalars (e.g. integers) are not supported by serde_urlencoded
-        let error = http::Request::builder().query(&42).unwrap_err();
-
-        assert!(matches!(error, SetQueryError::Encode(_)));
+        let _error: serde_urlencoded::ser::Error = http::Request::builder().query(&42).unwrap_err();
     }
 }

--- a/tower-http-client/tests/mocks.rs
+++ b/tower-http-client/tests/mocks.rs
@@ -1,4 +1,5 @@
 use http::{HeaderValue, header::USER_AGENT};
+use pretty_assertions::assert_eq;
 use reqwest::Client;
 use tower::ServiceBuilder;
 use tower_http::ServiceBuilderExt;
@@ -156,7 +157,7 @@ async fn test_service_ext_put_json() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[cfg(feature = "typed-header")]
-async fn test_service_ext_typed_header() -> anyhow::Result<()> {
+async fn test_request_ext_typed_header() -> anyhow::Result<()> {
     use headers::{HeaderMapExt as _, UserAgent};
     use wiremock::Request;
 
@@ -183,6 +184,49 @@ async fn test_service_ext_typed_header() -> anyhow::Result<()> {
     let response = client
         .get(format!("{mock_uri}/hello"))
         .typed_header(UserAgent::from_static("wiremock"))
+        .send()
+        .await?;
+
+    assert!(response.status().is_success());
+
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg(feature = "query")]
+async fn test_request_ext_query() -> anyhow::Result<()> {
+    use wiremock::Request;
+
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    struct Query {
+        id: &'static str,
+        next: &'static str,
+    }
+
+    let (mock_server, mock_uri) = utils::start_mock_server().await;
+
+    Mock::given(method("GET"))
+        .and(path("/hello"))
+        .respond_with(|req: &Request| {
+            let query = req.url.query().unwrap();
+            assert_eq!(query, "id=uid.1234&next=uid.1235");
+
+            ResponseTemplate::new(200)
+        })
+        // Mounting the mock on the mock server - it's now effective!
+        .mount(&mock_server)
+        .await;
+
+    let mut client = ServiceBuilder::new()
+        .layer(HttpClientLayer)
+        .service(Client::new());
+
+    let response = client
+        .get(format!("{mock_uri}/hello"))
+        .query(&Query {
+            id: "uid.1234",
+            next: "uid.1235",
+        })?
         .send()
         .await?;
 


### PR DESCRIPTION
- Added a `query` method to `ClientRequestBuilder` and `RequestBuilderExt` for
  setting URL query parameters from any `serde::Serialize` type. The method
  replaces any existing query string entirely. Available behind the `query`
  feature flag.