### PR TITLE
Release 0.6.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
@@ -8,163 +8,164 @@ and this project adheres to
 
 ## [Unreleased]
 
-- **breaking:** Bumped `reqwest` dependency version to `0.13`.
+- **Breaking:** Bumped the `reqwest` dependency to `0.13`.
 
-- Added `rewrite_uri` module with a `RewriteUri` trait and `RewriteUriLayer` /
-  `RewriteUriService` middleware pair for composable client-side URI rewriting
-  (e.g. load balancing, environment switching).
+- Added the `rewrite_uri` module with a `RewriteUri` trait and a
+  `RewriteUriLayer` / `RewriteUriService` middleware pair for composable
+  client-side URI rewriting (e.g. load balancing, environment switching).
 
 - Added a `query` method to `ClientRequestBuilder` and `RequestBuilderExt` for
   setting URL query parameters from any `serde::Serialize` type. The method
   replaces any existing query string entirely. Enabled by default via the
-  `query` feature flag, can be opted out with `default-features = false`.
+  `query` feature flag; it can be disabled with `default-features = false`.
 
-- **breaking:** Unified body types across `ClientRequestBuilder` methods.
+- **Breaking:** Unified body types across `ClientRequestBuilder` methods.
   `form()` now returns `Bytes` instead of `String`, and `send()` on the builder
   requires `From<Bytes>` instead of `Default`. All standard body-producing
-  methods (`send`, `without_body`, `json`, `form`) now uniformly produce
+  methods (`send`, `without_body`, `json`, `form`) now consistently produce
   `Bytes`, requiring only a single `From<Bytes>` bound on the service request
   body type.
 
-- **Breaking:** `url` and `serde` dependencies are now optional. Some
-  functionality has been moved behind feature flags `json` / `form` (enabling
-  `serde`) and `url`.
+- **Breaking:** Made the `url` and `serde` dependencies optional. Some
+  functionality is now behind the `json` / `form` (enabling `serde`) and `url`
+  feature flags.
 
-- Add the `MakeHeaderValue` trait bound to the `SetRequestHeaderLayer` generic
-  parameter in the `tower-request` crate (otherwise the resulting type won't
-  implement `Service`)
+- Added the `MakeHeaderValue` trait bound to the `SetRequestHeaderLayer` generic
+  parameter in the `tower-request` crate so the resulting type implements
+  `Service`.
 
-- **breaking:** Improved integration with `reqwest`: request body conversion now
-  uses `reqwest::Body::wrap` instead of `into_reqwest_body` method.
-  `ClientRequestBuilder` method `without_body` now returns a `Bytes` type in
-  order to improve compatibility with other HTTP clients.
+- **Breaking:** Improved integration with `reqwest`: request body conversion now
+  uses `reqwest::Body::wrap` instead of a custom `into_reqwest_body` method.
+  `ClientRequestBuilder::without_body` now returns `Bytes` to improve
+  compatibility with other HTTP clients.
 
-- **breaking:** Renamed `build` method to `without_body` in `ClientRequest` to
-  better reflect its purpose and improve API clarity.
+- **Breaking:** Renamed the `build` method to `without_body` on `ClientRequest`
+  to better reflect its purpose and improve API clarity.
 
-- **breaking:** Removed `reqwest` dependency from `tower-http-client` to
-  eliminate dependency on specific versions of `reqwest`. The crate is now fully
-  generic and does not tie to any HTTP client implementation. Users needing
-  `reqwest`-specific features should use **`tower-reqwest`** directly.
+- **Breaking:** Removed the direct `reqwest` dependency from `tower-http-client`
+  to avoid pinning a specific `reqwest` version. The crate is now fully generic
+  and not tied to any particular HTTP client implementation. Users who need
+  `reqwest`-specific features should use `tower-reqwest` directly.
 
-- **breaking:** Updated the request adapter (`HttpClientService` /
+- **Breaking:** Updated the request adapter (`HttpClientService` /
   `ExecuteRequestFuture`) to propagate `S::Error` directly (now constrained to
   `request::Error`) instead of wrapping it in a crate-specific error type.
 
 - Refactored `ExecuteRequestFuture` in `tower-reqwest` to remove unnecessary
-  double pinning, simplifying the internal structure.
+  double-pinning and simplify the internal structure.
 
-## [0.5.3] - 2025.09.23
+## [0.5.3] - 2025-09-23
 
 - Improved `Debug` implementations for `ClientRequest` and
   `ClientRequestBuilder`.
 
-- Added `From<ClientRequest>` implementation for `http::Request` and
+- Added `From<ClientRequest>` for `http::Request` and
   `From<ClientRequestBuilder>` for `http::request::Builder` to help with
   debugging and testing.
 
-- Bump minimum supported Rust version to `1.88.0`.
+- Bumped the minimum supported Rust version to `1.88.0`.
 
-## [0.5.2] - 2025.04.04
+## [0.5.2] - 2025-04-04
 
-- Added a `typed_header` method to the `ClientRequest` and `RequestBuilderExt`
-  for typed header insertion.
+- Added a `typed_header` method to `ClientRequest` and `RequestBuilderExt` for
+  inserting typed headers.
 
-- Made trait `RequestBuilderExt` sealed.
+- Made the `RequestBuilderExt` trait sealed.
 
-## [0.5.1] - 2025.04.01
+## [0.5.1] - 2025-04-01
 
-- **breaking** `body_reader` implementation has been replaced with the
+- **Breaking:** Replaced the `body_reader` implementation with the
   `http_body_reader` crate.
 
 - Added a `form` method to the `BodyReader` to decode form data.
 
-- **breaking:** Split the old `ClientRequest` into separate builder and request
+- **Breaking:** Split the old `ClientRequest` into separate builder and request
   structs with updated error handling.
 
-- Introduced a `RequestBuilderExt` trait to extend the `http::request::Builder`
-  with additional methods to send a form data and a JSON objects.
+- Introduced the `RequestBuilderExt` trait to extend `http::request::Builder`
+  with additional methods to send form data and JSON objects.
 
-- Bump minimum supported Rust version to `1.81`.
+- Bumped the minimum supported Rust version to `1.81.0`.
 
-- **breaking:** Made `request_builder` module private.
+- **Breaking:** Made the `request_builder` module private.
 
-- Added a `form` method to the `ClientRequest` to send a form data.
+- Added a `form` method to `ClientRequest` to send form data.
 
-- **breaking:** Removed the own implementation of the `BoxCloneSyncService`,
-  please use the `tower::util::BoxCloneSyncService` instead.
+- **Breaking:** Removed the crate's own implementation of `BoxCloneSyncService`;
+  please use `tower::util::BoxCloneSyncService` instead.
 
-- Added an `auth` module to the `tower-reqwest` crate, which provides a way to
-  add an authorization header to the requests.
+- Added an `auth` module to the `tower-reqwest` crate to add authorization
+  headers to requests.
 
-- Added a `set-header` module to the `tower-reqwest` crate, which provides a way
-  to modify the request headers.
+- Added a `set-header` module to the `tower-reqwest` crate to modify request
+  headers.
 
-## [0.4.1] - 2024.12.04
+## [0.4.1] - 2024-12-04
 
-- Fix typos in the documentation.
-- Bump minimum supported Rust version to `1.78`.
+- Fixed typos in the documentation.
+- Bumped the minimum supported Rust version to `1.78.0`.
 
-## [0.4.0] - 2024.10.14
+## [0.4.0] - 2024-10-14
 
-- **breaking:** Extensions and utilities for Tower services that provides HTTP
-  client implementations have been moved to the `client` module.
+- **Breaking:** Extensions and utilities for Tower services that provide HTTP
+  client implementations were moved to the `client` module.
 
-- **breaking:** `ClientRequest` and `ServiceBuilderExt` methods now use the
-  `IntoUri` trait instead of `Uri: TryFrom` conversion in order to improve
-  interopability with the `url` crate.
+- **Breaking:** `ClientRequest` and `ServiceBuilderExt` methods now accept the
+  `IntoUri` trait instead of relying on `Uri: TryFrom` to improve
+  interoperability with the `url` crate.
 
-- Added `#[from]` and `#[source]` to `Error` and `ClientError` to expose the
-  underlying source error.
+- Added `#[from]` and `#[source]` to `Error` and `ClientError` to expose
+  underlying source errors.
 
 - Added a `BoxCloneSyncService`, borrowed from this
   [PR](https://github.com/tower-rs/tower/pull/777).
 
-- **breaking:** `request` module has been renamed to the `request_builder`.
+- **Breaking:** Renamed the `request` module to `request_builder`.
 
-- **breaking:** Removed `reqwest-middleware` feature from the
+- **Breaking:** Removed the `reqwest-middleware` feature from the
   `tower-http-client` and `tower-http` crates.
 
 - Added a [retry](tower-http-client/examples/retry.rs) example.
 
-- Added a [rate-limiter](tower-http-client/examples/rate_limiter.rs) example.
-- **breaking:** Changed `ServiceBuilder::execute` signature to be more
+- Added a [rate limiter](tower-http-client/examples/rate_limiter.rs) example.
+
+- **Breaking:** Changed the `ServiceBuilder::execute` signature to be more
   compatible with the `Service::call` method.
 
-## [0.3.2] - 2024.05.05
+## [0.3.2] - 2024-05-05
 
-- Added more information about crates.
-- The minimum supported Rust version is set to 1.75.
+- Added more information about the crates.
+- Set the minimum supported Rust version to `1.75.0`.
 
-## [0.3.1] - 2024.05.03
+## [0.3.1] - 2024-05-03
 
-- Added a `reqwest` and `reqwest-middleware` features to the `tower-http-client`
+- Added `reqwest` and `reqwest-middleware` features to the `tower-http-client`
   crate.
 
-## [0.3.0] - 2024.04.30
+## [0.3.0] - 2024-04-30
 
-- Added an `ResponseExt` extension trait.
+- Added a `ResponseExt` extension trait.
 
 - Added a `json` feature to enable reading and writing JSON bodies in requests
   and responses.
 
-- Added a `request` module with the useful utilities like `ClientRequest` for
+- Added a `request` module with utilities such as `ClientRequest` for
   constructing HTTP requests.
 
-- A separate feature `util` has been removed, now this functionality is always
+- Removed the separate `util` feature; the functionality is now always
   available.
 
-- Added a new module `body_reader` in the [`tower-http-client`] to simplify the
-  reading the response body in the most common cases.
+- Added a `body_reader` module in `tower-http-client` to simplify reading
+  response bodies in common cases.
 
-- `tower_http_client::util::HttpClientExt` has been replaced by the
+- Replaced `tower_http_client::util::HttpClientExt` with
   `tower_http_client::ServiceExt`.
 
-## [0.2.0] - 2024.04.21
+## [0.2.0] - 2024-04-21
 
-- The `tower-reqwest` has been split into two parts: [`tower-reqwest`] itself
-  with adapters for `tower-http` and [`tower-http-client`] with the useful utils
-  and extensions for creating an clients.
+- The `tower-reqwest` project was split into two parts: `tower-reqwest` itself,
+  which contains adapters for `tower-http`, and `tower-http-client`, which
+  contains utilities and extensions for creating clients.
 
 [`tower-http-client`]: tower-http-client
 [`tower-reqwest`]: tower-reqwest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **breaking:** Bumped `reqwest` dependency version to `0.13`.
+
 - Added `rewrite_uri` module with a `RewriteUri` trait and `RewriteUriLayer` /
   `RewriteUriService` middleware pair for composable client-side URI rewriting
   (e.g. load balancing, environment switching).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,14 +1242,13 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1261,32 +1260,28 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
 ]
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
 dependencies = [
  "anyhow",
  "async-trait",
  "http",
  "reqwest",
- "serde",
- "thiserror 1.0.69",
+ "thiserror",
  "tower-service",
 ]
 
@@ -1470,31 +1465,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1605,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "tower-http-client"
-version = "0.6.0-alpha.3"
+version = "0.6.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1625,7 +1600,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tower",
  "tower-http",
@@ -1644,7 +1619,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-reqwest"
-version = "0.6.0-alpha.3"
+version = "0.6.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1657,7 +1632,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tower",
  "tower-http",
@@ -1873,19 +1848,6 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["tower-http-client", "tower-reqwest"]
 [workspace.package]
 edition = "2024"
 rust-version = "1.89"
-version = "0.6.0-alpha.3"
+version = "0.6.0-rc.1"
 categories = [
   "asynchronous",
   "network-programming",
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/alekseysidorov/tower-http-client"
 
 [workspace.dependencies]
-tower-reqwest = { version = "0.6.0-alpha.3", path = "tower-reqwest" }
+tower-reqwest = { version = "0.6.0-rc.1", path = "tower-reqwest" }
 
 anyhow = "1.0"
 async-trait = "0.1"
@@ -33,8 +33,8 @@ http-body-util = "0.1"
 include-utils = "0.2"
 pin-project = "1.1"
 pretty_assertions = "1.4"
-reqwest = { version = "0.12", default-features = false, features = ["stream"] }
-reqwest-middleware = "0.4.2"
+reqwest = { version = "0.13.2", default-features = false }
+reqwest-middleware = "0.5.1"
 retry-policies = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/tower-http-client/Cargo.toml
+++ b/tower-http-client/Cargo.toml
@@ -57,7 +57,7 @@ tower-reqwest = { workspace = true }
 wiremock = { workspace = true }
 
 [features]
-default = ["form", "json", "typed-header", "query", "rewrite-uri"]
+default = ["url", "form", "json", "typed-header", "query", "rewrite-uri"]
 form = ["dep:serde", "dep:serde_urlencoded", "http-body-reader/form"]
 json = ["dep:serde", "dep:serde_json", "http-body-reader/json"]
 url = ["dep:url"]


### PR DESCRIPTION
- reqwest -> 0.13.2 (drop 'stream' feature), 
- reqwest-middleware -> 0.5.1
- Bump workspace/tower-reqwest to 0.6.0-rc.1. 